### PR TITLE
Update callbacks

### DIFF
--- a/src/P4estTypes.jl
+++ b/src/P4estTypes.jl
@@ -13,6 +13,8 @@ export lengthoflocalquadrants, lengthofglobalquadrants # Find better names
 export level, storeuserdata!, loaduserdata
 export offset
 export iterateforest
+export refine!, coarsen!, balance!, partition!
+export lnodes, ghostlayer
 
 include("sc.jl")
 
@@ -26,6 +28,8 @@ uses_mpi() = P4est.uses_mpi()
 
 include("connectivity.jl")
 include("pxest.jl")
+include("lnodes.jl")
+include("ghost.jl")
 
 function __init__()
     if !SC.initialized()

--- a/src/ghost.jl
+++ b/src/ghost.jl
@@ -1,15 +1,15 @@
-mutable struct GhostLayer{X,P}
+mutable struct GhostLayer{X,T,P}
     pointer::P
-    function GhostLayer{4}(pointer::Ptr{p4est_ghost_t})
-        ghost = new{4,typeof(pointer)}(pointer)
+    function GhostLayer{4}(pointer::Ptr{p4est_ghost_t}, ::Type{T}) where {T}
+        ghost = new{4,T,typeof(pointer)}(pointer)
         finalizer(ghost) do p
             p4est_ghost_destroy(p.pointer)
             p.pointer = C_NULL
             return
         end
     end
-    function GhostLayer{8}(pointer::Ptr{p8est_ghost_t})
-        ghost = new{8,typeof(pointer)}(pointer)
+    function GhostLayer{8}(pointer::Ptr{p8est_ghost_t}, ::Type{T}) where {T}
+        ghost = new{8,T,typeof(pointer)}(pointer)
         finalizer(ghost) do p
             p8est_ghost_destroy(p.pointer)
             p.pointer = C_NULL
@@ -18,20 +18,20 @@ mutable struct GhostLayer{X,P}
     end
 end
 
-function ghostlayer(forest::Pxest{X}; connection = CONNECT_FULL(Val(X))) where {X}
-    return GhostLayer{X}((pxest_ghost_new(Val(X)))(forest, connection))
+function ghostlayer(forest::Pxest{X,T}; connection = CONNECT_FULL(Val(X))) where {X,T}
+    return GhostLayer{X}((pxest_ghost_new(Val(X)))(forest, connection), T)
 end
 
 function Base.unsafe_convert(
     ::Type{Ptr{p4est_ghost_t}},
-    p::GhostLayer{4,Ptr{p4est_ghost_t}},
-)
+    p::GhostLayer{4,T,Ptr{p4est_ghost_t}},
+) where {T}
     return p.pointer
 end
 
 function Base.unsafe_convert(
     ::Type{Ptr{p8est_ghost_t}},
-    p::GhostLayer{8,Ptr{p8est_ghost_t}},
-)
+    p::GhostLayer{8,T,Ptr{p8est_ghost_t}},
+) where {T}
     return p.pointer
 end

--- a/src/ghost.jl
+++ b/src/ghost.jl
@@ -1,0 +1,37 @@
+mutable struct GhostLayer{X,P}
+    pointer::P
+    function GhostLayer{4}(pointer::Ptr{p4est_ghost_t})
+        ghost = new{4,typeof(pointer)}(pointer)
+        finalizer(ghost) do p
+            p4est_ghost_destroy(p.pointer)
+            p.pointer = C_NULL
+            return
+        end
+    end
+    function GhostLayer{8}(pointer::Ptr{p8est_ghost_t})
+        ghost = new{8,typeof(pointer)}(pointer)
+        finalizer(ghost) do p
+            p8est_ghost_destroy(p.pointer)
+            p.pointer = C_NULL
+            return
+        end
+    end
+end
+
+function ghostlayer(forest::Pxest{X}; connection = CONNECT_FULL(Val(X))) where {X}
+    return GhostLayer{X}((pxest_ghost_new(Val(X)))(forest, connection))
+end
+
+function Base.unsafe_convert(
+    ::Type{Ptr{p4est_ghost_t}},
+    p::GhostLayer{4,Ptr{p4est_ghost_t}},
+)
+    return p.pointer
+end
+
+function Base.unsafe_convert(
+    ::Type{Ptr{p8est_ghost_t}},
+    p::GhostLayer{8,Ptr{p8est_ghost_t}},
+)
+    return p.pointer
+end

--- a/src/ghost.jl
+++ b/src/ghost.jl
@@ -22,6 +22,41 @@ function ghostlayer(forest::Pxest{X,T}; connection = CONNECT_FULL(Val(X))) where
     return GhostLayer{X}((pxest_ghost_new(Val(X)))(forest, connection), T)
 end
 
+struct Ghosts{X,T,P} <: AbstractArray{Quadrant,1}
+    pointer::P
+end
+
+Base.size(g::Ghosts) = (g.pointer.elem_count,)
+Base.@propagate_inbounds function Base.getindex(g::Ghosts{X,T}, i::Int) where {X,T}
+    @boundscheck checkbounds(g, i)
+    GC.@preserve g begin
+        Q = pxest_quadrant_t(Val(X))
+        quadrant = Ptr{Q}(g.pointer.array + sizeof(Q) * (i - 1))
+        return Quadrant{X,T,Ptr{Q}}(quadrant)
+    end
+end
+Base.IndexStyle(::Ghosts) = IndexLinear()
+
+struct Mirrors{X,T,P} <: AbstractArray{Quadrant,1}
+    pointer::P
+end
+
+Base.size(m::Mirrors) = (m.pointer.elem_count,)
+Base.@propagate_inbounds function Base.getindex(m::Mirrors{X,T}, i::Int) where {X,T}
+    @boundscheck checkbounds(m, i)
+    GC.@preserve m begin
+        Q = pxest_quadrant_t(Val(X))
+        quadrant = Ptr{Q}(m.pointer.array + sizeof(Q) * (i - 1))
+        return Quadrant{X,T,Ptr{Q}}(quadrant)
+    end
+end
+Base.IndexStyle(::Mirrors) = IndexLinear()
+
+ghosts(gl::GhostLayer{X,T}) where {X,T} =
+    Ghosts{X,T,typeof(gl.pointer.ghosts)}(gl.pointer.ghosts)
+mirrors(gl::GhostLayer{X,T}) where {X,T} =
+    Mirrors{X,T,typeof(gl.pointer.mirrors)}(gl.pointer.mirrors)
+
 function Base.unsafe_convert(
     ::Type{Ptr{p4est_ghost_t}},
     p::GhostLayer{4,T,Ptr{p4est_ghost_t}},

--- a/src/lnodes.jl
+++ b/src/lnodes.jl
@@ -1,0 +1,34 @@
+mutable struct LNodes{X,P}
+    pointer::P
+    function LNodes{4}(pointer::Ptr{P4est.LibP4est.p4est_lnodes})
+        nodes = new{4,typeof(pointer)}(pointer)
+        finalizer(nodes) do p
+            p4est_lnodes_destroy(p.pointer)
+            p.pointer = C_NULL
+            return
+        end
+    end
+    function LNodes{8}(pointer::Ptr{P4est.LibP4est.p8est_lnodes})
+        nodes = new{8,typeof(pointer)}(pointer)
+        finalizer(nodes) do p
+            p8est_lnodes_destroy(p.pointer)
+            p.pointer = C_NULL
+            return
+        end
+    end
+end
+
+function lnodes(forest::Pxest{X}; ghost = nothing, degree = 1) where {X}
+    if isnothing(ghost)
+        ghost = ghostlayer(forest)
+    end
+    return LNodes{X}((pxest_lnodes_new(Val(X)))(forest, ghost, degree))
+end
+
+function Base.unsafe_convert(::Type{Ptr{p4est_lnodes}}, p::LNodes{4,Ptr{p4est_lnodes}})
+    return p.pointer
+end
+
+function Base.unsafe_convert(::Type{Ptr{p8est_lnodes}}, p::LNodes{8,Ptr{p8est_lnodes}})
+    return p.pointer
+end

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -68,7 +68,7 @@ function pxest(
     min_level = 0,
     fill_uniform = true,
     data_type = Nothing,
-    init_function = C_NULL,
+    init_function = nothing,
 )
     MPI.Initialized() || MPI.Init()
 
@@ -79,10 +79,18 @@ function pxest(
         min_level,
         fill_uniform,
         sizeof(data_type),
-        init_function,
+        C_NULL,
         C_NULL,
     )
-    return Pxest{4}(pointer, connectivity, comm, data_type)
+
+    forest = Pxest{4}(pointer, connectivity, comm, data_type)
+
+    if !isnothing(init_function)
+        init(forest, _, quadrant, _, treeid) = init_function(forest, treeid, quadrant)
+        iterateforest(forest; volume = init)
+    end
+
+    return forest
 end
 
 function pxest(
@@ -92,9 +100,11 @@ function pxest(
     min_level = 0,
     fill_uniform = true,
     data_type = Nothing,
-    init_function = C_NULL,
+    init_function = nothing,
 )
     MPI.Initialized() || MPI.Init()
+
+    @assert isnothing(init_function)
 
     pointer = p8est_new_ext(
         comm,
@@ -103,7 +113,7 @@ function pxest(
         min_level,
         fill_uniform,
         sizeof(data_type),
-        init_function,
+        C_NULL,
         C_NULL,
     )
     return Pxest{8}(pointer, connectivity, comm, data_type)

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -44,6 +44,7 @@ end
 
 @inline level(quadrant::Quadrant) = quadrant.pointer.level
 @inline coordinates(quadrant::Quadrant{4}) = (quadrant.pointer.x, quadrant.pointer.y)
+@inline which_tree(quadrant::Quadrant) = quadrant.pointer.p.piggy3.which_tree + 1
 @inline function coordinates(quadrant::Quadrant{8})
     return (quadrant.pointer.x, quadrant.pointer.y, quadrant.pointer.z)
 end

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -56,7 +56,7 @@ struct Tree{X,T,P} <: AbstractArray{Quadrant,1}
     pointer::P
 end
 
-Base.size(t::Tree) = (t.pointer.quadrants.elem_count,)
+Base.size(t::Tree) = (convert(Int, t.pointer.quadrants.elem_count),)
 function Base.getindex(t::Tree{X,T}, i::Int) where {X,T}
     @boundscheck checkbounds(t, i)
     GC.@preserve t begin
@@ -148,7 +148,7 @@ function Base.unsafe_convert(::Type{Ptr{p8est}}, p::Pxest{8,T,Ptr{p8est}}) where
     return p.pointer
 end
 
-Base.size(p::Pxest) = (p.pointer.trees.elem_count,)
+Base.size(p::Pxest) = (convert(Int, p.pointer.trees.elem_count),)
 function Base.getindex(p::Pxest{X,T}, i::Int) where {X,T}
     @boundscheck checkbounds(p, i)
     GC.@preserve p begin

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -164,17 +164,15 @@ function iterateforest(
     forest.pointer.user_pointer = pointer_from_objref(data)
 
     volume::Ptr{Cvoid} = isnothing(volume) ? C_NULL : generate_volume_callback(Val(X))
-
-    @assert ghost === nothing
     @assert face === nothing
     @assert edge === nothing
     @assert corner === nothing
 
     GC.@preserve data begin
         if X == 4
-            p4est_iterate(forest, C_NULL, C_NULL, volume_callback, C_NULL, C_NULL)
+            p4est_iterate(forest, ghost, C_NULL, volume, C_NULL, C_NULL)
         elseif X == 8
-            p8est_iterate(forest, C_NULL, C_NULL, volume_callback, C_NULL, C_NULL, C_NULL)
+            p8est_iterate(forest, ghost, C_NULL, volume, C_NULL, C_NULL, C_NULL)
         else
             error("Not implemented")
         end

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -42,7 +42,11 @@ struct Quadrant{X,T,P}
     pointer::P
 end
 
-level(quadrant::Quadrant) = quadrant.pointer.level
+@inline level(quadrant::Quadrant) = quadrant.pointer.level
+@inline coordinates(quadrant::Quadrant{4}) = (quadrant.pointer.x, quadrant.pointer.y)
+@inline function coordinates(quadrant::Quadrant{8})
+    return (quadrant.pointer.x, quadrant.pointer.y, quadrant.pointer.z)
+end
 storeuserdata!(quadrant::Quadrant{X,T}, data::T) where {X,T} =
     unsafe_store!(Ptr{T}(quadrant.pointer.p.user_data), data)
 loaduserdata(quadrant::Quadrant{X,T}) where {X,T} =
@@ -135,6 +139,7 @@ quadrantndims(::Pxest{8}) = 3
 typeofquadrantuserdata(::Pxest{X,T}) where {X,T} = T
 lengthoflocalquadrants(p::Pxest) = p.pointer.local_num_quadrants
 lengthofglobalquadrants(p::Pxest) = p.pointer.global_num_quadrants
+comm(p::Pxest) = p.comm
 
 function Base.unsafe_convert(::Type{Ptr{p4est}}, p::Pxest{4,T,Ptr{p4est}}) where {T}
     return p.pointer


### PR DESCRIPTION
- Don't use a closure for callback data
- Add quadrant initialization function
- Add iteration for p8est
- Pass ghost when iterating
- Add refine, coarsen, balance, and partition
- Add misc getter functions
- Use `Int` when returning sizes of p4est objects
- Add quadrant user data type to `GhostLayer`
- Add ghost layer mirrors and ghosts quadrant arrays
- Add function to get quadrant tree information
