### PR TITLE
add pretty printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Lucas C Wilcox <lucas@swirlee.com>"]
 version = "0.1.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 P4est = "7d669430-f675-4ae7-b43e-fab78ec5a902"

--- a/src/P4estTypes.jl
+++ b/src/P4estTypes.jl
@@ -1,5 +1,6 @@
 module P4estTypes
 
+using AbstractTrees: print_tree
 using CBinding
 using MPI
 using P4est

--- a/src/pxest.jl
+++ b/src/pxest.jl
@@ -433,3 +433,26 @@ function partition!(
 
     return
 end
+
+import Base:show 
+function Base.show(io::IO, forest::P4estTypes.Pxest{X}) where{X}
+    print("Forest{$X} with $(length(forest)) trees.")
+end
+
+# A p4est "forest" object is represented as an AbstractArray of AbstractArrays, 
+# which AbstractTrees.jl automatically recognizes as a printable tree. 
+function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, forest::P4estTypes.Pxest)
+    print_tree(forest)
+end
+
+function Base.show(io::IO, tree::Tree{X}) where {X}
+    print("Tree{$X} with $(length(tree)) quadrants.")
+end
+
+function Base.show(io::IO, q::Quadrant{X}) where {X}
+    print("Quadrant{$X}: level $(level(q)), coordinates $(coordinates(q)).")
+end
+
+# - forest = array of trees
+# - tree = array of quadrant
+# - quadrant has fields `*.pointer.x/y/z(if in 3D)/level`

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -35,5 +35,11 @@
         4 7 5 8
     ]
 
-    @test isvalid(Connectivity{4}(VXYZ, EToV))
+    conn = Connectivity{4}(VXYZ, EToV)
+    @test isvalid(conn)
+
+    # test default `refine` argument
+    p4est = pxest(conn, min_level=2)
+    @test length(p4est)==4 # 4 trees
+    @test all(length.(p4est) .== 16) # each tree has 16 quadrants due to min_level = 2
 end


### PR DESCRIPTION
Also fixes the default refinement function in `refine!`

Example output for a forest with 4 trees initialized with `min_level=1`

```julia
Forest{4} with 4 trees.
├─ Tree{4} with 4 quadrants.
│  ├─ Quadrant{4}: level 1, coordinates (0, 0).
│  ├─ Quadrant{4}: level 1, coordinates (536870912, 0).
│  ├─ Quadrant{4}: level 1, coordinates (0, 536870912).
│  └─ Quadrant{4}: level 1, coordinates (536870912, 536870912).
├─ Tree{4} with 4 quadrants.
│  ├─ Quadrant{4}: level 1, coordinates (0, 0).
│  ├─ Quadrant{4}: level 1, coordinates (536870912, 0).
│  ├─ Quadrant{4}: level 1, coordinates (0, 536870912).
│  └─ Quadrant{4}: level 1, coordinates (536870912, 536870912).
├─ Tree{4} with 4 quadrants.
│  ├─ Quadrant{4}: level 1, coordinates (0, 0).
│  ├─ Quadrant{4}: level 1, coordinates (536870912, 0).
│  ├─ Quadrant{4}: level 1, coordinates (0, 536870912).
│  └─ Quadrant{4}: level 1, coordinates (536870912, 536870912).
└─ Tree{4} with 4 quadrants.
   ├─ Quadrant{4}: level 1, coordinates (0, 0).
   ├─ Quadrant{4}: level 1, coordinates (536870912, 0).
   ├─ Quadrant{4}: level 1, coordinates (0, 536870912).
   └─ Quadrant{4}: level 1, coordinates (536870912, 536870912).
```